### PR TITLE
Adding CF_PLUGIN_HOME mapped to /cf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 
+# Make a directory for CloudFoundry storage
+RUN mkdir /cf
+ENV CF_PLUGIN_HOME /cf
+
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.22.2' | tar -zx -C /usr/local/bin
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
 RUN cf install-plugin autopilot -f -r CF-Community


### PR DESCRIPTION
Created a `/cf` directory to store plugins during the build. These are later referenced by `cf` using the [`CF_PLUGIN_HOME`](https://docs.cloudfoundry.org/cf-cli/use-cli-plugins.html#listing-plugin-repo) environment variable.